### PR TITLE
Rename .env.Production to .env.production

### DIFF
--- a/frontend/.env.Production
+++ b/frontend/.env.Production
@@ -1,1 +1,0 @@
-BACKEND_URL=https://if220098.cloud.htl-leonding.ac.at:8000/api/

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+BACKEND_URL=https://if220098.cloud.htl-leonding.ac.at:8000/api/


### PR DESCRIPTION
Next.js uses .env.local, .env.development or .env.production depending on Build-Mode